### PR TITLE
[FIX] Http tracker can not send Completed and Stopped events to the announce

### DIFF
--- a/lib/src/tracker/http_tracker.dart
+++ b/lib/src/tracker/http_tracker.dart
@@ -35,26 +35,6 @@ class HttpTracker extends Tracker with HttpTrackerBase {
   }
 
   @override
-  Future<PeerEvent?> stop([bool force = false]) async {
-    await close();
-    var f = super.stop(force);
-    return f;
-  }
-
-  @override
-  Future<PeerEvent?> complete() async {
-    await close();
-    var f = super.complete();
-    return f;
-  }
-
-  @override
-  Future dispose([dynamic reason]) async {
-    await close();
-    return super.dispose(reason);
-  }
-
-  @override
   Future<PeerEvent?> announce(String eventType, Map<String, dynamic> options) {
     _currentEvent =
         eventType; // save the current event, stop and complete will also call this method, so the current event type should be recorded here

--- a/lib/src/tracker/tracker.dart
+++ b/lib/src/tracker/tracker.dart
@@ -135,7 +135,7 @@ abstract class Tracker with EventsEmittable<TrackerEvent> {
     return true;
   }
 
-  Future dispose([dynamic reason]) async {
+  Future<void> dispose([dynamic reason]) async {
     if (_disposed) return;
     events.dispose();
     _disposed = true;


### PR DESCRIPTION
Issue Description:
Currently, `Completed` and `Stopped` events are not being delivered to the announcement.

What is the fix:
- [x] Remove unnecessary `close()` calls in `HttpTracker` before proceeding with `stop()`, `complete()`, and `dispose()` methods, because all `super` calls of such methods call `close()` upon the end of the method.
- [x] Add tests